### PR TITLE
Remove versioned DLL imports

### DIFF
--- a/src/lib/modplug/modplug.pas
+++ b/src/lib/modplug/modplug.pas
@@ -25,7 +25,7 @@ uses
     {$LINKLIB libmodplug.a}
   {$ELSE}
     {$DEFINE MP_DYNAMIC}
-    const modpluglib = 'libmodplug-1.dll';
+    const modpluglib = 'libmodplug.dll';
   {$ENDIF}
 {$ELSEIF DEFINED(UNIX)}
   {$DEFINE MP_DYNAMIC}

--- a/src/lib/mpg123/mpg123.pas
+++ b/src/lib/mpg123/mpg123.pas
@@ -33,7 +33,7 @@ uses
     {$LINKLIB libmpg123.a}
   {$ELSE}
     {$DEFINE MPG123_DYNAMIC}
-    const LIB_MPG123 = 'libmpg123-0.dll';
+    const LIB_MPG123 = 'libmpg123.dll';
   {$ENDIF}
 {$ELSEIF DEFINED(UNIX)}
   {$DEFINE MPG123_DYNAMIC}

--- a/src/lib/opus/opus.pas
+++ b/src/lib/opus/opus.pas
@@ -30,8 +30,8 @@ uses
     {$LINKLIB libopus.a}
   {$ELSE}
     {$DEFINE OPUS_DYNAMIC}
-    const opuslib = 'libopus-0.dll';
-    const opusfilelib = 'libopusfile-0.dll';
+    const opuslib = 'libopus.dll';
+    const opusfilelib = 'libopusfile.dll';
   {$ENDIF}
 {$ELSEIF DEFINED(UNIX)}
   {$DEFINE OPUS_DYNAMIC}

--- a/src/lib/vorbis/ogg.pas
+++ b/src/lib/vorbis/ogg.pas
@@ -31,7 +31,7 @@ uses
     {$LINKLIB libogg.a}
   {$ELSE}
     {$DEFINE OGG_DYNAMIC}
-    const ogglib = 'libogg-0.dll';
+    const ogglib = 'ogg.dll';
   {$ENDIF}
 {$ELSEIF DEFINED(UNIX)}
   {$DEFINE OGG_DYNAMIC}

--- a/src/lib/vorbis/vorbis.pas
+++ b/src/lib/vorbis/vorbis.pas
@@ -32,8 +32,8 @@ uses
     {$LINKLIB libvorbis.a}
   {$ELSE}
     {$DEFINE OGG_DYNAMIC}
-    const vorbislib = 'libvorbis-0.dll';
-    const vorbisfilelib = 'libvorbisfile-3.dll';
+    const vorbislib = 'libvorbis.dll';
+    const vorbisfilelib = 'libvorbisfile.dll';
   {$ENDIF}
 {$ELSEIF DEFINED(UNIX)}
   {$DEFINE OGG_DYNAMIC}


### PR DESCRIPTION
Remove versioned DLL imports:

1. They are not consistent. Some are versioned, some are not
2. They do not really serve any purpose for the game, but instead cause problems linking with other libraries

Also rename the ogg import, because `ogg.dll` is used by OpenAL.