### PR TITLE
macOS: fix ChDir when not in bundle

### DIFF
--- a/src/game/g_main.pas
+++ b/src/game/g_main.pas
@@ -713,8 +713,8 @@ begin
       // External storage is the path where bundled files get copied to.
       ChDir(SDL_AndroidGetExternalStoragePath());
   {$ELSEIF DEFINED(DARWIN)}
-    if GetBundlePath() <> '' then
-      Chdir(ConcatPaths([GetBundlePath(), 'Contents/Resources']));
+    if ExtractFileExt(GetBundlePath()) = '.app' then
+      ChDir(ConcatPaths([GetBundlePath(), 'Contents/Resources']));
   {$ELSEIF DEFINED(USE_SDLMIXER) AND NOT DEFINED(ANDROID)}
     if e_TimidityDecoder and (newcwd <> '') then
     begin


### PR DESCRIPTION
A macOS build of the game can come in several forms, including plain .zip bundles. Remove the assumption that `GetBundlePath()` would always be used from a game launched in an .app bundle, because it returns garbage when the game is not