### PR TITLE
Use INTERMUS instead of ROUNDMUS for interlude

### DIFF
--- a/src/game/g_game.pas
+++ b/src/game/g_game.pas
@@ -1471,7 +1471,7 @@ begin
 
 {$IFDEF ENABLE_SOUND}
     g_Game_SetLoadingText(_lc[I_LOAD_MUSIC], 0, False);
-    g_Sound_CreateWADEx('MUSIC_INTERMUS', GameWAD+':MUSIC\INTERMUS', False);
+    g_Sound_CreateWADEx('MUSIC_INTERMUS', GameWAD+':MUSIC\INTERMUS', True);
     g_Sound_CreateWADEx('MUSIC_MENU', GameWAD+':MUSIC\MENU', True);
     g_Sound_CreateWADEx('MUSIC_STDENDMUS', GameWAD+':MUSIC\ENDMUS', True);
 {$ENDIF}

--- a/src/game/g_game.pas
+++ b/src/game/g_game.pas
@@ -1471,9 +1471,8 @@ begin
 
 {$IFDEF ENABLE_SOUND}
     g_Game_SetLoadingText(_lc[I_LOAD_MUSIC], 0, False);
-    g_Sound_CreateWADEx('MUSIC_INTERMUS', GameWAD+':MUSIC\INTERMUS', True);
+    g_Sound_CreateWADEx('MUSIC_INTERMUS', GameWAD+':MUSIC\INTERMUS', False);
     g_Sound_CreateWADEx('MUSIC_MENU', GameWAD+':MUSIC\MENU', True);
-    g_Sound_CreateWADEx('MUSIC_ROUNDMUS', GameWAD+':MUSIC\ROUNDMUS', True, True);
     g_Sound_CreateWADEx('MUSIC_STDENDMUS', GameWAD+':MUSIC\ENDMUS', True);
 {$ENDIF}
 
@@ -1962,7 +1961,7 @@ begin
                 else
                 begin
 {$IFDEF ENABLE_SOUND}
-                  gMusic.SetByName('MUSIC_ROUNDMUS');
+                  gMusic.SetByName('MUSIC_INTERMUS');
 {$ENDIF}
                 end;
 {$IFDEF ENABLE_SOUND}


### PR DESCRIPTION
This works fine at least with interludes up to 2 minutes, which is the longest amount of time allowed to set in game.