### PR TITLE
Android: don't use environment variables

### DIFF
--- a/src/game/g_main.pas
+++ b/src/game/g_main.pas
@@ -659,6 +659,7 @@ procedure Init();
 {$IFDEF USE_SDLMIXER}
 var
   timiditycfg: AnsiString;
+  sdlNativeMusic: AnsiString;
   oldcwd, newcwd: RawByteString;
 {$ENDIF}
 begin
@@ -687,6 +688,10 @@ begin
     Mix_SetSoundFonts(PChar(e_SoundFont));
   {$ENDIF}
 
+    // Android is not really Unix. Don't try environment variables there, because
+    // it may lead to unexpected behaviour and crashes.
+    // On newer Androids, getenv causes game to crash for some reason.
+    {$IF NOT DEFINED(ANDROID)}
     timiditycfg := GetEnvironmentVariable('TIMIDITY_CFG');
     if timiditycfg = '' then
     begin
@@ -700,8 +705,11 @@ begin
       else
         timiditycfg := '';
     end;
+
+    sdlNativeMusic := GetEnvironmentVariable('SDL_NATIVE_MUSIC');
+    {$ENDIF}
     e_LogWritefln('TIMIDITY_CFG = "%s"', [timiditycfg]);
-    e_LogWritefln('SDL_NATIVE_MUSIC = "%s"', [GetEnvironmentVariable('SDL_NATIVE_MUSIC')]);
+    e_LogWritefln('SDL_NATIVE_MUSIC = "%s"', [sdlNativeMusic]);
   {$ENDIF}
 
     e_InitSoundSystem({$IFDEF HEADLESS} True {$ELSE} False {$ENDIF});

--- a/src/shared/envvars.pas
+++ b/src/shared/envvars.pas
@@ -59,7 +59,10 @@ end;
   begin
     {$IF DEFINED(WINDOWS)}
       Result := utf2win(UTF8String(SysUtils.GetEnvironmentVariable(WideString('USERNAME'))));
-    {$ELSEIF DEFINED(UNIX)}
+    {$ELSEIF DEFINED(UNIX) AND NOT DEFINED(ANDROID)}
+      // Android is not really Unix. Don't try environment variables there, because
+      // it may lead to unexpected behaviour and crashes.
+      // On newer Androids, getenv causes game to crash for some reason.
       Result := utf2win(SysUtils.GetEnvironmentVariable('USER'));
     {$ELSE}
       Result := '';


### PR DESCRIPTION
This causes game to crash on newer version of Android for some reason. While I don't have enough brain power right now to debug through this right now, we don't have any need for environment variables on Android and can not use them safely.